### PR TITLE
Always publish the sha specific template

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,6 @@ jobs:
         run: make test
 
       - name: Do a test job
-        if: ${{ github.event_name == 'pull_request' }}
         run: make integ NAME=pr-${{github.event.pull_request.number}}-${{github.sha}} WHYLABS_API_KEY=${{secrets.WHYLABS_API_KEY}}
 
       - name: Upload template to GCS


### PR DESCRIPTION
Forgot that we're doing squash merges. Each merged PR will result in a new SHA so the one we upload for the PR won't end up in the master branch.