### PR TITLE
Fix broken dependencies in template

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,11 +49,27 @@ jobs:
         run: make test
 
       - name: Upload template to GCS
+        if: ${{ github.event_name == 'pull_request' }}
         run: poetry run make batch_bigquery_template SHA=${{github.sha}}
 
       - name: Do a test job
-        run: make integ NAME=pr-${{github.event.pull_request.number}}-${{github.sha}} WHYLABS_API_KEY=${{secrets.WHYLABS_API_KEY}} SHA=${{github.sha}}
+        if: ${{ github.event_name == 'pull_request' }}
+        run: | 
+          echo "Use the GCP console to verify that this test succeeds for the manual approval https://console.cloud.google.com/dataflow/jobs?project=whylogs-359820"
+          make integ NAME=pr-${{github.event.pull_request.number}}-${{github.sha}} \
+            SHA=${{github.sha}} \
+            WHYLABS_API_KEY=${{secrets.WHYLABS_API_KEY}} 
 
       - name: Upload template to GCS as 'latest'
         if: ${{ github.event_name == 'push' }}
         run: poetry run make batch_bigquery_template_latest
+
+  approve_integ_test:
+    name: Approve the integ test from the main workflow in GCS console
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    environment: 
+      name: main
+
+    steps:
+      - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,6 @@ jobs:
     name: Push the latest versions of the templates to GCS
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    container:
-      image: google/cloud-sdk
 
     permissions:
       contents: "read"
@@ -31,7 +29,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: "3.8"
+          python-version: "3.8.15"
 
       - uses: Gr1N/setup-poetry@v7
         name: Install poetry
@@ -50,11 +48,11 @@ jobs:
       - name: Run test
         run: make test
 
-      - name: Do a test job
-        run: make integ NAME=pr-${{github.event.pull_request.number}}-${{github.sha}} WHYLABS_API_KEY=${{secrets.WHYLABS_API_KEY}}
-
       - name: Upload template to GCS
         run: poetry run make batch_bigquery_template SHA=${{github.sha}}
+
+      - name: Do a test job
+        run: make integ NAME=pr-${{github.event.pull_request.number}}-${{github.sha}} WHYLABS_API_KEY=${{secrets.WHYLABS_API_KEY}} SHA=${{github.sha}}
 
       - name: Upload template to GCS as 'latest'
         if: ${{ github.event_name == 'push' }}

--- a/Makefile
+++ b/Makefile
@@ -144,10 +144,10 @@ version_metadata:
 requirements: requirements.txt template_requirements.txt integ_requirements.txt
 
 requirements.txt: pyproject.toml
-	poetry export -f requirements.txt > requirements.txt
+	poetry export -f requirements.txt --with dev > requirements.txt
 
 template_requirements.txt: pyproject.toml
-	poetry export -f requirements.txt --without dev --with beam > template_requirements.txt
+	poetry export -f requirements.txt --without dev > template_requirements.txt
 
 integ_requirements.txt: pyproject.toml
 	poetry export -f requirements.txt --without dev > integ_requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ REQUIREMENTS=requirements.txt
 
 .PHONY: default batch_bigquery_template upload_template 
 .PHONY: example_run_direct_table example_run_template_table example_run_template_query example_run_template_offset
-.PHONY: lint format format-fix test setup version_metadata help
+.PHONY: lint format format-fix test setup version_metadata help requirements
 
 default:help
 
@@ -23,8 +23,7 @@ batch_bigquery_template_latest: upload_template version_metadata ## Upload the d
 batch_bigquery_template: NAME=batch_bigquery_template
 batch_bigquery_template: upload_template version_metadata ## Upload the dataflow template that profiles a query
 
-integ: REQUIREMENTS=integ_requirements.txt
-integ: integ_requirements.txt example_run_direct_table 
+integ: example_run_template_table
 
 example_run_direct_table: JOB_NAME=$(NAME)
 example_run_direct_table: TEMPLATE=batch_bigquery_template
@@ -142,11 +141,13 @@ version_metadata:
 	echo "$(SHA)" > /tmp/version_$(SHA).sha
 	gcloud storage cp /tmp/version_$(SHA).sha $(TEMPLATE_LOCATION)/$(VERSION)/version.sha
 
+requirements: requirements.txt template_requirements.txt integ_requirements.txt
+
 requirements.txt: pyproject.toml
 	poetry export -f requirements.txt > requirements.txt
 
 template_requirements.txt: pyproject.toml
-	poetry export -f requirements.txt --without dev --without beam > template_requirements.txt
+	poetry export -f requirements.txt --without dev --with beam > template_requirements.txt
 
 integ_requirements.txt: pyproject.toml
 	poetry export -f requirements.txt --without dev > integ_requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -144,10 +144,10 @@ version_metadata:
 requirements: requirements.txt template_requirements.txt integ_requirements.txt
 
 requirements.txt: pyproject.toml
-	poetry export -f requirements.txt --with dev > requirements.txt
+	poetry export -f requirements.txt > requirements.txt
 
 template_requirements.txt: pyproject.toml
-	poetry export -f requirements.txt --without dev > template_requirements.txt
+	poetry export -f requirements.txt --without dev --with beam > template_requirements.txt
 
 integ_requirements.txt: pyproject.toml
 	poetry export -f requirements.txt --without dev > integ_requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,6 @@ python = "3.8.*"
 whylogs = {version = "1.1.12", extras = ["whylabs"]}
 pandas = "^1.5.1"
 python-dateutil = "^2.8.2"
-
-[tool.poetry.group.beam.dependencies]
 apache-beam = {extras = ["gcp"], version = "^2.42.0"}
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ python = "3.8.*"
 whylogs = {version = "1.1.12", extras = ["whylabs"]}
 pandas = "^1.5.1"
 python-dateutil = "^2.8.2"
+
+[tool.poetry.group.beam.dependencies]
 apache-beam = {extras = ["gcp"], version = "^2.42.0"}
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
I had mistakenly generated the requirements file without apache beam which made all template runs fail. I have CI in here but it runs before the template exists by executing the pipeline directly.

The mistake is fixed now and the CI is updated to upload a template whenever the PR is submitted so that a test can be done using the template.