### PR TITLE
add warning to NaN columns

### DIFF
--- a/src/ai/whylabs/templates/batch_bigquery_template.py
+++ b/src/ai/whylabs/templates/batch_bigquery_template.py
@@ -146,7 +146,14 @@ class SegmentedProfileViews(beam.DoFn):
             # https://github.com/pandas-dev/pandas/issues/47963
             if len(dataframe) == 0:
                 continue
-
+            
+            if len(self.segment_columns_list) > 1:
+                for col in self.segment_columns_list:
+                    if dataframe[col].isna().values.any():
+                        self.logger.warning(
+                            "Segmenting on columns with NaN's can lead to a whylogs error"
+                        )
+            
             result_set = why.log(dataframe, schema=dataset_schema)
             views_list: List[SegmentedDatasetProfileView] = result_set.get_writables()
             for segmented_view in views_list:

--- a/src/ai/whylabs/templates/batch_bigquery_template.py
+++ b/src/ai/whylabs/templates/batch_bigquery_template.py
@@ -132,22 +132,20 @@ class SegmentedProfileViews(beam.DoFn):
         start_time = time.perf_counter()
         tmp_date_col = "_whylogs_datetime"
         df = pd.DataFrame(batch)
-        
+
         # This can be removed after issue on whylogs is solved
         # https://github.com/whylabs/whylogs/issues/1300
         if len(self.segment_columns_list) > 1:
             for col in self.segment_columns_list:
                 if df[col].isna().values.any():
                     raise ValueError(f"Segmenting with nullable columns {col} is not supported.")
-        
+
         df[tmp_date_col] = pd.to_datetime(df[self.date_column])
         if df[tmp_date_col].isna().values.any():
             self.logger.warning(f"Column {self.date_column} has NaT rows which will be dropped by the template.")
         grouped = df.set_index(tmp_date_col).groupby(pd.Grouper(freq=self.freq))
 
         self.logger.info(f"Using {','.join(self.segment_columns_list)} for segmentation")
-        
-
 
         segmentation_partition = SegmentationPartition(
             name=",".join(self.segment_columns_list), mapper=ColumnMapperFunction(col_names=self.segment_columns_list)

--- a/src/ai/whylabs/templates/batch_bigquery_template.py
+++ b/src/ai/whylabs/templates/batch_bigquery_template.py
@@ -136,6 +136,14 @@ class SegmentedProfileViews(beam.DoFn):
         grouped = df.set_index(tmp_date_col).groupby(pd.Grouper(freq=self.freq))
 
         self.logger.info(f"Using {','.join(self.segment_columns_list)} for segmentation")
+        
+        # This can be removed after issue on whylogs is solved
+        # https://github.com/whylabs/whylogs/issues/1300
+        if len(self.segment_columns_list) > 1:
+            for col in self.segment_columns_list:
+                if df[col].isna().values.any():
+                    raise ValueError(f"Segmenting with nullable columns {col} is not supported.")
+
 
         segmentation_partition = SegmentationPartition(
             name=",".join(self.segment_columns_list), mapper=ColumnMapperFunction(col_names=self.segment_columns_list)
@@ -148,11 +156,6 @@ class SegmentedProfileViews(beam.DoFn):
             # https://github.com/pandas-dev/pandas/issues/47963
             if len(dataframe) == 0:
                 continue
-
-            if len(self.segment_columns_list) > 1:
-                for col in self.segment_columns_list:
-                    if dataframe[col].isna().values.any():
-                        self.logger.warning(f"Segmenting on column {col} with null values leads to a whylogs KeyError")
 
             result_set = why.log(dataframe, schema=dataset_schema)
             views_list: List[SegmentedDatasetProfileView] = result_set.get_writables()

--- a/src/ai/whylabs/templates/batch_bigquery_template.py
+++ b/src/ai/whylabs/templates/batch_bigquery_template.py
@@ -86,6 +86,8 @@ class ProfileViews(beam.DoFn):
         tmp_date_col = "_whylogs_datetime"
         df = pd.DataFrame(batch)
         df[tmp_date_col] = pd.to_datetime(df[self.date_column])
+        if df[tmp_date_col].isna().values.any():
+            self.logger.warning(f"Column {self.date_column} has NaT rows which will be dropped by the template.")
         grouped = df.set_index(tmp_date_col).groupby(pd.Grouper(freq=self.freq))
 
         results: List[Tuple[str, DatasetProfileView]] = []
@@ -130,12 +132,6 @@ class SegmentedProfileViews(beam.DoFn):
         start_time = time.perf_counter()
         tmp_date_col = "_whylogs_datetime"
         df = pd.DataFrame(batch)
-        df[tmp_date_col] = pd.to_datetime(df[self.date_column])
-        if df[tmp_date_col].isna().values.any():
-            self.logger.warning(f"Column {self.date_column} has NaT rows which will be dropped by the template.")
-        grouped = df.set_index(tmp_date_col).groupby(pd.Grouper(freq=self.freq))
-
-        self.logger.info(f"Using {','.join(self.segment_columns_list)} for segmentation")
         
         # This can be removed after issue on whylogs is solved
         # https://github.com/whylabs/whylogs/issues/1300
@@ -143,6 +139,14 @@ class SegmentedProfileViews(beam.DoFn):
             for col in self.segment_columns_list:
                 if df[col].isna().values.any():
                     raise ValueError(f"Segmenting with nullable columns {col} is not supported.")
+        
+        df[tmp_date_col] = pd.to_datetime(df[self.date_column])
+        if df[tmp_date_col].isna().values.any():
+            self.logger.warning(f"Column {self.date_column} has NaT rows which will be dropped by the template.")
+        grouped = df.set_index(tmp_date_col).groupby(pd.Grouper(freq=self.freq))
+
+        self.logger.info(f"Using {','.join(self.segment_columns_list)} for segmentation")
+        
 
 
         segmentation_partition = SegmentationPartition(

--- a/src/ai/whylabs/templates/batch_bigquery_template.py
+++ b/src/ai/whylabs/templates/batch_bigquery_template.py
@@ -151,7 +151,7 @@ class SegmentedProfileViews(beam.DoFn):
                 for col in self.segment_columns_list:
                     if dataframe[col].isna().values.any():
                         self.logger.warning(
-                            "Segmenting on columns with NaN's can lead to a whylogs error"
+                            f"Segmenting on column {col} with null values leads to a whylogs KeyError"
                         )
             
             result_set = why.log(dataframe, schema=dataset_schema)

--- a/src/ai/whylabs/templates/batch_bigquery_template.py
+++ b/src/ai/whylabs/templates/batch_bigquery_template.py
@@ -146,14 +146,12 @@ class SegmentedProfileViews(beam.DoFn):
             # https://github.com/pandas-dev/pandas/issues/47963
             if len(dataframe) == 0:
                 continue
-            
+
             if len(self.segment_columns_list) > 1:
                 for col in self.segment_columns_list:
                     if dataframe[col].isna().values.any():
-                        self.logger.warning(
-                            f"Segmenting on column {col} with null values leads to a whylogs KeyError"
-                        )
-            
+                        self.logger.warning(f"Segmenting on column {col} with null values leads to a whylogs KeyError")
+
             result_set = why.log(dataframe, schema=dataset_schema)
             views_list: List[SegmentedDatasetProfileView] = result_set.get_writables()
             for segmented_view in views_list:


### PR DESCRIPTION
details:
- it is a known issue on whylogs ([#1300](https://github.com/whylabs/whylogs/issues/1300)) when segmenting by multiple columns that if one of them has NaNs, the pipeline breaks
- adding a warn log that is more informative to what has happened
- adding a warn for NaT on the `ProfileViews` class as well